### PR TITLE
Fix #4 Support more Server Sent Events

### DIFF
--- a/examples/server-sent-event-example/build.gradle
+++ b/examples/server-sent-event-example/build.gradle
@@ -5,8 +5,8 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsVersion"
-        classpath "com.bertramlabs.plugins:asset-pipeline-gradle:2.8.2"
-        classpath "org.grails.plugins:hibernate5:6.0.0.M2"
+        classpath "com.bertramlabs.plugins:asset-pipeline-gradle:2.11.6"
+        classpath "org.grails.plugins:hibernate5:6.0.6"
     }
 }
 
@@ -44,11 +44,12 @@ dependencies {
     compile "org.grails.plugins:scaffolding"
     compile "org.grails.plugins:rx-mongodb"
     compile "org.grails.plugins:rx-gorm-rest-client:1.0.0.M1"
-    compile "org.grails.plugins:rxjava:1.0.0-SNAPSHOT"
+    compile project(":rxjava")
+    compile 'org.grails.plugins:quartz:2.0.9'
 
     console "org.grails:grails-console"
     profile "org.grails.profiles:web"
-    runtime "com.bertramlabs.plugins:asset-pipeline-grails:2.8.2"
+    runtime "com.bertramlabs.plugins:asset-pipeline-grails:2.11.6"
     runtime "com.h2database:h2"
     testCompile "org.grails:grails-plugin-testing"
     testCompile "org.grails.plugins:geb"

--- a/examples/server-sent-event-example/gradle.properties
+++ b/examples/server-sent-event-example/gradle.properties
@@ -1,2 +1,2 @@
-grailsVersion=3.2.0.M2
+grailsVersion=3.2.5
 gradleWrapperVersion=2.13

--- a/examples/server-sent-event-example/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/server-sent-event-example/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Nov 27 23:09:32 CET 2015
+#Thu Feb 09 15:18:01 AEDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip

--- a/examples/server-sent-event-example/grails-app/controllers/rxjava/demo/TickTockController.groovy
+++ b/examples/server-sent-event-example/grails-app/controllers/rxjava/demo/TickTockController.groovy
@@ -1,29 +1,101 @@
 package rxjava.demo
 
-import rx.Subscriber
+import grails.converters.JSON
 import grails.rx.web.*
+import io.reactivex.Emitter
+import io.reactivex.Observable
+import io.reactivex.schedulers.Schedulers
+import io.reactivex.subjects.PublishSubject
+import io.reactivex.subjects.Subject
+import reactor.spring.context.annotation.Consumer
+import reactor.spring.context.annotation.Selector
+
+import java.util.concurrent.TimeUnit
+
 /**
  * Created by graemerocher on 28/07/2016.
  */
+@Consumer
 class TickTockController implements RxController {
 
     def index() {
-        rx.stream { Subscriber subscriber ->
+        rx.stream { Emitter emitter ->
             for(i in (0..5)) {
                 if(i % 2 == 0) {
-                    subscriber.onNext(
+                    emitter.onNext(
                         rx.render("Tick")
                     )
                 }
                 else {
-                    subscriber.onNext(
+                    emitter.onNext(
                         rx.render("Tock")
                     )
 
                 }
                 sleep 1000
             }
-            subscriber.onCompleted()
+            emitter.onComplete()
         }
+    }
+
+    def sse() {
+        def lastId = request.getHeader('Last-Event-ID') as Integer
+        def startId = lastId ? lastId + 1 : 0
+        log.info("Last Event ID: $lastId")
+        rx.stream { Emitter emitter ->
+            log.info("SSE Thread ${Thread.currentThread().name}")
+            for(i in (startId..(startId+9))) {
+                if(i % 2 == 0) {
+                    emitter.onNext(
+                            rx.event("Tick\n$i", id: i, event: 'tick', comment: 'tick')
+                    )
+                }
+                else {
+                    emitter.onNext(
+                            rx.event("Tock\n$i", id: i, event: 'tock', comment: 'tock')
+                    )
+
+                }
+                sleep 1000
+            }
+            emitter.onComplete()
+        }
+    }
+
+    def observable() {
+        def lastId = request.getHeader('Last-Event-ID') as Integer
+        def startId = lastId ? lastId + 1 : 0
+        rx.stream(
+                Observable
+                        .interval(1, TimeUnit.SECONDS)
+                        .doOnSubscribe { log.info("Observable Subscribe Thread ${Thread.currentThread().name}") }
+                        .doOnNext { log.info("Observable Thread ${Thread.currentThread().name}") }
+                        .map {
+                            def id = it + startId
+                            rx.event([type: 'observable', num: id] as JSON, id: id, comment: 'hello')
+                        }
+                        .take(10),
+        )
+    }
+
+    Subject subject = PublishSubject.create()
+    Observable publishedObservable = subject.publish().autoConnect().observeOn(Schedulers.io())
+
+    @Selector('MyJob.event')
+    void myEventListener(Object data) {
+        log.info("myEvent listener Thread ${Thread.currentThread().name}")
+        subject.onNext(data)
+    }
+
+    def quartz() {
+        rx.stream(
+                publishedObservable
+                        .doOnSubscribe { log.info("Quartz Subscribe Thread ${Thread.currentThread().name}") }
+                        .doOnError { log.info("Quartz thread error") }
+                        .map {
+                            log.info("Quartz Thread ${Thread.currentThread().name}")
+                            rx.event([type: 'quartz', num: it as int] as JSON, comment: 'hello')
+                        }
+        )
     }
 }

--- a/examples/server-sent-event-example/grails-app/jobs/rxjava/demo/MyJob.groovy
+++ b/examples/server-sent-event-example/grails-app/jobs/rxjava/demo/MyJob.groovy
@@ -1,0 +1,21 @@
+package rxjava.demo
+
+import grails.events.Events
+
+class MyJob implements Events {
+    static triggers = {
+        simple name: 'mySimpleTrigger', startDelay: 1000, repeatInterval: 1000
+    }
+    def group = "MyGroup"
+    def description = "Example job with Simple Trigger"
+
+    static int i = 0
+
+    static final String EVENT_NAME = 'MyJob.event'
+
+    def execute(){
+        log.trace('MyJob.execute()')
+
+        notify EVENT_NAME, "${i++}"
+    }
+}

--- a/examples/server-sent-event-example/grails-app/views/index.gsp
+++ b/examples/server-sent-event-example/grails-app/views/index.gsp
@@ -14,7 +14,24 @@ function tickTock() {
         console.log("data: "+event.data)
         document.getElementById('message').innerHTML = event.data;
     };
-
+    // handling different event types
+    var handler = function(event) {
+        console.log("data: "+event.data);
+        document.getElementById('events').innerHTML = event.data;
+    };
+    var events = new EventSource("tickTock/sse");
+    events.addEventListener('tick', handler);
+    events.addEventListener('tock', handler);
+    var observable = new EventSource("tickTock/observable");
+    observable.onmessage = function (event) {
+        console.log("observable data: " + event.data);
+        document.getElementById('observable').innerHTML = event.data;
+    };
+    var quartz = new EventSource("tickTock/quartz");
+    quartz.onmessage = function (event) {
+        console.log("quartz data: " + event.data);
+        document.getElementById('quartz').innerHTML = event.data;
+    };
 }
 tickTock()
     </script>
@@ -68,6 +85,9 @@ tickTock()
         <section class="row colset-2-its">
             <h1>Welcome to Grails</h1>
             <h2 style="text-align:center;font-size:50px" id="message"></h2>
+            <pre style="text-align:center;font-size:50px" id="events"></pre>
+            <h2 style="text-align:center;font-size:50px" id="observable"></h2>
+            <h2 style="text-align:center;font-size:50px" id="quartz"></h2>
             <p>
                 Congratulations, you have successfully started your first Grails application! At the moment
                 this is the default page, feel free to modify it to either redirect to a controller or display

--- a/examples/server-sent-event-example/settings.gradle
+++ b/examples/server-sent-event-example/settings.gradle
@@ -1,0 +1,2 @@
+include ":rxjava"
+project(":rxjava").projectDir = file("../../")

--- a/src/main/groovy/grails/rx/web/helper/RxHelper.groovy
+++ b/src/main/groovy/grails/rx/web/helper/RxHelper.groovy
@@ -3,13 +3,17 @@ package grails.rx.web.helper
 import grails.rx.web.Rx
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.SimpleType
 import io.reactivex.Emitter
 import io.reactivex.Observable
+import org.codehaus.groovy.runtime.GStringImpl
 import org.grails.plugins.rx.web.NewObservableResult
 import org.grails.plugins.rx.web.ObservableResult
 import org.grails.plugins.rx.web.StreamingNewObservableResult
 import org.grails.plugins.rx.web.StreamingObservableResult
 import org.grails.plugins.rx.web.result.RxResult
+import org.grails.plugins.rx.web.sse.SseResult
 import org.grails.web.converters.Converter
 
 import javax.servlet.http.HttpServletRequest
@@ -117,6 +121,148 @@ class RxHelper {
      */
     RxResult<Converter> render(Converter converter) {
         Rx.render(converter)
+    }
+
+    /**
+     * Create a Server Sent Event without data
+     *
+     * @param sseOptions optional Server Sent Event arguments (comment, id, event, retry)
+     * @return The SSE Event
+     */
+    SseResult event(Map sseOptions) {
+        Rx.event(sseOptions, (Writable) null)
+    }
+
+    /**
+     * Use a writable to create a Server Sent Event
+     *
+     * @param sseOptions optional Server Sent Event arguments (comment, id, event, retry)
+     * @param writable The writable
+     * @return The SSE Event
+     */
+    SseResult event(Map sseOptions, Writable writable) {
+        Rx.event(sseOptions, writable)
+    }
+
+    /**
+     * Use a writable to create a Server Sent Event
+     *
+     * @param writable The writable
+     * @return The SSE Event
+     */
+    SseResult event(Writable writable) {
+        Rx.event([:], writable)
+    }
+
+    /**
+     * Use a converter to create a Server Sent Event
+     *
+     * @param sseOptions optional Server Sent Event arguments (comment, id, event, retry)
+     * @param converter The converter
+     * @return The SSE Event
+     */
+    SseResult event(Map sseOptions, Converter converter) {
+        Rx.event(sseOptions, converter)
+    }
+
+    /**
+     * Use a converter to create a Server Sent Event
+     *
+     * @param converter The converter
+     * @return The SSE Event
+     */
+    SseResult event(Converter writable) {
+        Rx.event([:], writable)
+    }
+
+    /**
+     * Use a GString to create a Server Sent Event
+     *
+     * @param sseOptions optional Server Sent Event arguments (comment, id, event, retry)
+     * @param gString The GString
+     * @return The SSE Event
+     */
+    // required for GStrings in @CompileStatic, @TypeChecked otherwise compiler can't decide between Writable or CharSequence method
+    SseResult event(Map sseOptions, GString gString) {
+        Rx.event(sseOptions, (Writable)gString)
+    }
+
+    /**
+     * Use a GString to create a Server Sent Event
+     *
+     * @param gString The GString
+     * @return The SSE Event
+     */
+    // required for GStrings in @CompileStatic, @TypeChecked otherwise compiler can't decide between Writable or CharSequence method
+    SseResult event(GString gString) {
+        Rx.event([:], (Writable)gString)
+    }
+
+    /**
+     * Use a GString to create a Server Sent Event
+     *
+     * @param sseOptions optional Server Sent Event arguments (comment, id, event, retry)
+     * @param gString The GString
+     * @return The SSE Event
+     */
+    // required for GStrings in @CompileDynamic, @TypeChecked otherwise runtime can't decide between Writable or CharSequence method
+    SseResult event(Map sseOptions, GStringImpl gString) {
+        Rx.event(sseOptions, (Writable)gString)
+    }
+
+    /**
+     * Use a GString to create a Server Sent Event
+     *
+     * @param gString The GString
+     * @return The SSE Event
+     */
+    // required for GStrings in @CompileDynamic, @TypeChecked otherwise runtime can't decide between Writable or CharSequence method
+    SseResult event(GStringImpl gString) {
+        Rx.event([:], (Writable)gString)
+    }
+
+    /**
+     * Use a CharSequence to create a Server Sent Event
+     *
+     * @param sseOptions optional Server Sent Event arguments (comment, id, event, retry)
+     * @param charSequence The CharSequence
+     * @return The SSE Event
+     */
+    SseResult event(Map sseOptions, CharSequence charSequence) {
+        Rx.event(sseOptions, charSequence)
+    }
+
+    /**
+     * Use a CharSequence to create a Server Sent Event
+     *
+     * @param charSequence The CharSequence
+     * @return The SSE Event
+     */
+    SseResult event(CharSequence charSequence) {
+        Rx.event([:], charSequence)
+    }
+
+    /**
+     * Use a Closure to create a Server Sent Event.  The closure will be passed a {@link Writer} as the only argument
+     * which it can use to write the data for the event to.
+     *
+     * @param sseOptions optional Server Sent Event arguments (comment, id, event, retry)
+     * @param closure The closure
+     * @return The SSE Event
+     */
+    SseResult event(Map sseOptions, @ClosureParams(value = SimpleType, options = ['java.io.Writer']) Closure closure) {
+        Rx.event(sseOptions, closure)
+    }
+
+    /**
+     * Use a Closure to create a Server Sent Event.  The closure will be passed a {@link Writer} as the only argument
+     * which it can use to write the data for the event to.
+     *
+     * @param closure The closure
+     * @return The SSE Event
+     */
+    SseResult event(@ClosureParams(value = SimpleType, options = ['java.io.Writer']) Closure closure) {
+        Rx.event([:], closure)
     }
 
     /**

--- a/src/main/groovy/org/grails/plugins/rx/web/RxResultSubscriber.groovy
+++ b/src/main/groovy/org/grails/plugins/rx/web/RxResultSubscriber.groovy
@@ -13,6 +13,7 @@ import io.reactivex.disposables.Disposable
 import org.grails.plugins.rx.web.result.ForwardResult
 import org.grails.plugins.rx.web.result.RxCompletionStrategy
 import org.grails.plugins.rx.web.result.RxResult
+import org.grails.plugins.rx.web.sse.SseResult
 import org.grails.plugins.web.async.GrailsAsyncContext
 import org.grails.web.errors.GrailsExceptionResolver
 import org.grails.web.servlet.mvc.GrailsWebRequest
@@ -164,6 +165,17 @@ class RxResultSubscriber implements AsyncListener, Observer {
                 response.flushBuffer()
 
             }
+        }
+        else if (o instanceof SseResult) {
+            SseResult sseResult = (SseResult) o
+            def response = asyncContext.response
+            def writer = response.writer
+            if (!sseResult.event && serverSendEventName) {
+                sseResult.event = serverSendEventName
+            }
+            sseResult.writeTo(writer)
+            completionStrategy = RxCompletionStrategy.COMPLETE
+            response.flushBuffer()
         }
         else if(o instanceof HttpStatus) {
             // if the item emitted is an HttpStatus object set the status

--- a/src/main/groovy/org/grails/plugins/rx/web/sse/SseResult.groovy
+++ b/src/main/groovy/org/grails/plugins/rx/web/sse/SseResult.groovy
@@ -1,0 +1,44 @@
+package org.grails.plugins.rx.web.sse
+
+import groovy.transform.CompileStatic
+
+/**
+ * A Server Sent Events event that can be written to an event stream
+ */
+@CompileStatic
+class SseResult implements Writable {
+
+    static final String ID_PREFIX = 'id'
+    static final String EVENT_PREFIX = 'event'
+    static final String DATA_PREFIX = 'data'
+    static final String RETRY_PREFIX = 'retry'
+
+    String id = null
+    String event = null
+    String comment = null
+    Long retry = null
+    Writable data = null
+
+    @Override
+    Writer writeTo(Writer out) throws IOException {
+        if ((!id && !event && !comment && !data)) {
+            return out
+        }
+
+        if (comment != null) out.write(": ${toSseString(comment)}\n")
+        if (id != null) out.write("$ID_PREFIX: ${toSseString(id)}\n")
+        if (event != null) out.write("$EVENT_PREFIX: ${toSseString(event)}\n")
+        if (retry != null) out.write("$RETRY_PREFIX: $retry\n")
+        if (data != null) {
+            out.write("$DATA_PREFIX: ")
+            data.writeTo(new SseWriter(out, DATA_PREFIX))
+            out.write('\n')
+        }
+        out.write('\n')
+        return out
+    }
+
+    static String toSseString(String input) {
+        input.replace('\n', ' ')
+    }
+}

--- a/src/main/groovy/org/grails/plugins/rx/web/sse/SseWriter.groovy
+++ b/src/main/groovy/org/grails/plugins/rx/web/sse/SseWriter.groovy
@@ -1,0 +1,55 @@
+package org.grails.plugins.rx.web.sse
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class SseWriter extends FilterWriter {
+
+    private static final char NEW_LINE = '\n'
+    private final String prefix
+
+    SseWriter(Writer out, String prefix) {
+        super(out)
+        this.prefix = prefix + ': '
+    }
+
+    void write(int c) throws IOException {
+        if (c == (int) NEW_LINE) {
+            out.write(c)
+            out.write(prefix)
+        } else {
+            out.write(c)
+        }
+    }
+
+    void write(char[] cbuf, int off, int len) throws IOException {
+        int lastNewLine = 0
+
+        for (int i = 0; i < len; ++i) {
+            if (cbuf[off + i] == NEW_LINE) {
+                out.write(cbuf, off + lastNewLine, i + 1 - lastNewLine)
+                out.write(prefix)
+                lastNewLine = i + 1
+            }
+        }
+        out.write(cbuf, off + lastNewLine, len - lastNewLine)
+    }
+
+    void write(String str, int off, int len) throws IOException {
+        int lastNewLine = 0
+
+        for (int i = 0; i < len; ++i) {
+            if (str.charAt(off + i) == NEW_LINE) {
+                out.write(str, off + lastNewLine, i + 1 - lastNewLine)
+                out.write(prefix)
+                lastNewLine = i + 1
+            }
+        }
+        out.write(str, off + lastNewLine, len - lastNewLine)
+    }
+
+    @Override
+    void close() throws IOException {
+        // don't close underlying stream
+    }
+}

--- a/src/test/groovy/org/grails/plugins/rx/EventSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/rx/EventSpec.groovy
@@ -1,0 +1,151 @@
+package org.grails.plugins.rx
+
+import grails.artefact.Controller
+import grails.artefact.controller.RestResponder
+import grails.converters.JSON
+import grails.rx.web.helper.RxHelper
+import grails.test.mixin.TestMixin
+import grails.test.mixin.web.ControllerUnitTestMixin
+import grails.util.GrailsWebMockUtil
+import io.reactivex.Emitter
+import org.grails.plugins.rx.web.RxResultTransformer
+import org.grails.plugins.rx.web.StreamingNewObservableResult
+import org.grails.web.servlet.mvc.GrailsWebRequest
+import org.grails.web.util.GrailsApplicationAttributes
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.web.context.request.RequestContextHolder
+import spock.lang.Specification
+
+@TestMixin(ControllerUnitTestMixin)
+class EventSpec extends Specification {
+
+    void "test stream an observable"() {
+        setup:
+        GrailsWebRequest webRequest = GrailsWebMockUtil.bindMockWebRequest()
+        MockHttpServletRequest request = webRequest.getCurrentRequest()
+        request.setAsyncSupported(true)
+        EventController controller = new EventController()
+        request.setAttribute(GrailsApplicationAttributes.CONTROLLER, controller)
+
+        when:"An action is rendered that creates an observable"
+        def observable = controller.stream()
+
+        then:"The result is correct"
+        observable instanceof StreamingNewObservableResult
+
+        when:"The observable is transformed"
+        RxResultTransformer transformer = new RxResultTransformer()
+        def result = transformer.transformActionResult(webRequest, "stream", observable)
+        then:"null is returned"
+        result == null
+        webRequest.response.contentType == RxResultTransformer.CONTENT_TYPE_EVENT_STREAM
+        webRequest.response.contentAsString == ''': potato
+id: 0
+event: Event 0
+data: Foo 0
+data: Foo
+data: Bar
+data: Baz
+
+: potato
+id: 1
+event: Event 1
+data: Foo 1
+data: Foo
+data: Bar
+data: Baz
+
+: potato
+id: 2
+event: Event 2
+data: Foo 2
+data: Foo
+data: Bar
+data: Baz
+
+: potato
+id: 3
+event: Event 3
+data: Foo 3
+data: Foo
+data: Bar
+data: Baz
+
+'''
+
+        cleanup:
+        RequestContextHolder.setRequestAttributes(null)
+    }
+
+    void "test stream json as an observable"() {
+        setup:
+        GrailsWebRequest webRequest = GrailsWebMockUtil.bindMockWebRequest()
+        MockHttpServletRequest request = webRequest.getCurrentRequest()
+        request.setAsyncSupported(true)
+        EventController controller = new EventController()
+        request.setAttribute(GrailsApplicationAttributes.CONTROLLER, controller)
+
+        when:"An action is rendered that creates an observable"
+        def observable = controller.streamJson()
+
+        then:"The result is correct"
+        observable instanceof StreamingNewObservableResult
+
+        when:"The observable is transformed"
+        RxResultTransformer transformer = new RxResultTransformer()
+        def result = transformer.transformActionResult(webRequest, "stream", observable)
+        then:"null is returned"
+        result == null
+        webRequest.response.contentType == RxResultTransformer.CONTENT_TYPE_EVENT_STREAM
+        webRequest.response.contentAsString == '''id: 0
+retry: 1000
+data: {"foo":"bar 0\\nbar 0","baz":3}
+
+id: 1
+retry: 1000
+data: {"foo":"bar 1\\nbar 1","baz":3}
+
+id: 2
+retry: 1000
+data: {"foo":"bar 2\\nbar 2","baz":3}
+
+id: 3
+retry: 1000
+data: {"foo":"bar 3\\nbar 3","baz":3}
+
+'''
+
+        cleanup:
+        RequestContextHolder.setRequestAttributes(null)
+    }
+
+}
+
+class EventController implements Controller, RestResponder{
+
+    RxHelper rx = new RxHelper()
+
+    def stream() {
+        rx.stream { Emitter subscriber ->
+            for(i in 0..3) {
+                subscriber.onNext(
+                        rx.event("Foo $i\nFoo\nBar\nBaz", event: "Event $i", comment: 'potato', id: "$i")
+                )
+            }
+            subscriber.onComplete()
+        }
+    }
+
+    def streamJson() {
+        rx.stream { Emitter subscriber ->
+            for(i in 0..3) {
+                def foo =  """bar $i
+bar $i"""
+                subscriber.onNext(
+                        rx.event([foo: foo, 'baz': 3] as JSON, id: "$i", retry: 1000)
+                )
+            }
+            subscriber.onComplete()
+        }
+    }
+}

--- a/src/test/groovy/org/grails/plugins/rx/web/sse/SseWriterSpec.groovy
+++ b/src/test/groovy/org/grails/plugins/rx/web/sse/SseWriterSpec.groovy
@@ -1,0 +1,94 @@
+package org.grails.plugins.rx.web.sse
+
+import spock.lang.Specification
+
+class SseWriterSpec extends Specification {
+
+    static final char NEW_LINE = '\n'
+
+    void "test write(int)"() {
+        setup:
+        def sw = new StringWriter()
+        def writer = new SseWriter(sw, 'a')
+
+        when:
+        writer.write('foo')
+        writer.write(NEW_LINE)
+        writer.write('foo')
+
+        then:
+        sw.toString() == 'foo\na: foo'
+    }
+
+    void "test write(cbuf)"() {
+        setup:
+        def sw = new StringWriter()
+        def writer = new SseWriter(sw, prefix)
+
+        when:
+        writer.write(input.chars)
+
+        then:
+        sw.toString() == output
+
+        where:
+        prefix << ['a','b','b']
+        input << ['𐐀oo\r\nfo𐐀\nf𐐀o\n', '', '\n\n\r\n\r\n']
+        output << ['𐐀oo\r\na: fo𐐀\na: f𐐀o\na: ', '', '\nb: \nb: \r\nb: \r\nb: ']
+    }
+
+    void "test write(cbuf, off, len)"() {
+        setup:
+        def sw = new StringWriter()
+        def writer = new SseWriter(sw, prefix)
+
+        when:
+        writer.write(input.chars, offset, length)
+
+        then:
+        sw.toString() == output
+
+        where:
+        prefix << ['a','b','b']
+        input << ['-----foo\r\nfoo\nfoo\n', '--------', '\n\n\r\n\r\n----']
+        offset << [5, 4, 0]
+        length << [13, 0, 6]
+        output << ['foo\r\na: foo\na: foo\na: ', '', '\nb: \nb: \r\nb: \r\nb: ']
+    }
+
+    void "test write(string)"() {
+        setup:
+        def sw = new StringWriter()
+        def writer = new SseWriter(sw, prefix)
+
+        when:
+        writer.write(input)
+
+        then:
+        sw.toString() == output
+
+        where:
+        prefix << ['a','b','b']
+        input << ['𐐀oo\r\nfo𐐀\nf𐐀o\n', '', '\n\n\r\n\r\n']
+        output << ['𐐀oo\r\na: fo𐐀\na: f𐐀o\na: ', '', '\nb: \nb: \r\nb: \r\nb: ']
+    }
+
+    void "test write(string, off, len)"() {
+        setup:
+        def sw = new StringWriter()
+        def writer = new SseWriter(sw, prefix)
+
+        when:
+        writer.write(input, offset, length)
+
+        then:
+        sw.toString() == output
+
+        where:
+        prefix << ['a','b','b']
+        input << ['-----foo\r\nfoo\nfoo\n', '--------', '\n\n\r\n\r\n----']
+        offset << [5, 4, 0]
+        length << [13, 0, 6]
+        output << ['foo\r\na: foo\na: foo\na: ', '', '\nb: \nb: \r\nb: \r\nb: ']
+    }
+}


### PR DESCRIPTION
 - Provide a new type that RxResultSubscriber knows about: `SseResult`
 - `SseResult` and helper methods provide ways of constructing Server Sent Events with comments, ids, retry and multiline data
 - Update example with `SseResult` usage and make example use local copy of plugin.