### PR TITLE
RxResultSubscriber log noise: Broken pipe

### DIFF
--- a/src/main/groovy/org/grails/plugins/rx/web/RxResultSubscriber.groovy
+++ b/src/main/groovy/org/grails/plugins/rx/web/RxResultSubscriber.groovy
@@ -272,7 +272,7 @@ class RxResultSubscriber implements AsyncListener, Observer {
             }
             else if(!asyncComplete) {
                 if(e != null)  {
-                    log.error("Async Dispatch Error: ${e.message}", e)
+                    log.debug("Async Dispatch Error: ${e.message}", e)
                 }
                 else {
                     log.debug("Async timeout occurred")


### PR DESCRIPTION
Avoid logging broken pipe as an error.
See  #[](https://github.com/grails-plugins/grails-rxjava/issues/14)